### PR TITLE
feat: refresh ui and add virtual assistant

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,228 +14,51 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/js/splide.min.js"></script>
     
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .card-hover {
-            transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-        }
-        
-        .card-hover:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 20px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, #4A7CE8 100%);
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.3);
-        }
-        
-        .team-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 16px;
-            transition: all 0.3s ease;
-            overflow: hidden;
-        }
-        
-        .team-card:hover {
-            border-color: var(--accent-primary);
-            box-shadow: 0 10px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .equipment-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(47, 203, 137, 0.1);
-            border-radius: 16px;
-            transition: all 0.3s ease;
-        }
-        
-        .equipment-card:hover {
-            border-color: var(--accent-success);
-            box-shadow: 0 10px 40px rgba(47, 203, 137, 0.1);
-        }
-        
-        .timeline-item {
-            position: relative;
-            padding-left: 2rem;
-            margin-bottom: 2rem;
-        }
-        
-        .timeline-item::before {
-            content: '';
-            position: absolute;
-            left: 0;
-            top: 0.5rem;
-            width: 12px;
-            height: 12px;
-            background: var(--accent-primary);
-            border-radius: 50%;
-        }
-        
-        .timeline-item::after {
-            content: '';
-            position: absolute;
-            left: 5px;
-            top: 1.5rem;
-            width: 2px;
-            height: calc(100% + 1rem);
-            background: rgba(91, 140, 255, 0.2);
-        }
-        
-        .timeline-item:last-child::after {
-            display: none;
-        }
-        
-        .certification-badge {
-            display: inline-flex;
-            align-items: center;
-            padding: 6px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-            background: rgba(47, 203, 137, 0.2);
-            color: var(--accent-success);
-            border: 1px solid rgba(47, 203, 137, 0.3);
-        }
-        
-        .stats-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 12px;
-            text-align: center;
-            transition: all 0.3s ease;
-        }
-        
-        .stats-card:hover {
-            border-color: var(--accent-primary);
-            transform: translateY(-2px);
-        }
-        
-        .image-gallery {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-            gap: 2rem;
-            margin: 2rem 0;
-        }
-        
-        .gallery-item {
-            background: var(--bg-secondary);
-            border-radius: 12px;
-            overflow: hidden;
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            transition: all 0.3s ease;
-        }
-        
-        .gallery-item:hover {
-            border-color: var(--accent-primary);
-            transform: translateY(-4px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.1);
-        }
-        
-        .gallery-image {
-            width: 100%;
-            height: 200px;
-            object-fit: cover;
-            background: linear-gradient(45deg, #1A1D23, #2D3748);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--text-secondary);
-            font-size: 14px;
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
+
 </head>
-<body>
+<body id="top">
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <a href="index.html" class="text-2xl font-bold text-gradient">Kykeon Analytics</a>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="text-gray-300 hover:text-white px-3 py-2">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-blue-400 hover:text-blue-300 px-3 py-2 font-medium">More</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Contact</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+            <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="results.html" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">RESULTS</a>
-                    <a href="index.html#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#top" class="btn-secondary">Explore</a>
             </div>
         </div>
     </nav>
@@ -808,46 +631,67 @@
     </section>
     
     <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
+            <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.</p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
             </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
+        <div class="footer-bottom">&copy; 2024 Kykeon Analytics. All rights reserved.</div>
     </footer>
     
-    <script>
+    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
+    <script src="ui.js"></script>
+<script>
         // Initialize animations
         document.addEventListener('DOMContentLoaded', function() {
             // Animate team cards

--- a/blog.html
+++ b/blog.html
@@ -13,173 +13,51 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .card-hover {
-            transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-        }
-        
-        .card-hover:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 20px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, #4A7CE8 100%);
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.3);
-        }
-        
-        .blog-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 16px;
-            transition: all 0.3s ease;
-            overflow: hidden;
-        }
-        
-        .blog-card:hover {
-            border-color: var(--accent-primary);
-            box-shadow: 0 10px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .blog-image {
-            width: 100%;
-            height: 200px;
-            background: linear-gradient(45deg, #1A1D23, #2D3748);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--text-secondary);
-            font-size: 14px;
-        }
-        
-        .category-badge {
-            display: inline-flex;
-            align-items: center;
-            padding: 4px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .category-harm-reduction {
-            background: rgba(47, 203, 137, 0.2);
-            color: var(--accent-success);
-            border: 1px solid rgba(47, 203, 137, 0.3);
-        }
-        
-        .category-research {
-            background: rgba(91, 140, 255, 0.2);
-            color: var(--accent-primary);
-            border: 1px solid rgba(91, 140, 255, 0.3);
-        }
-        
-        .category-policy {
-            background: rgba(255, 176, 32, 0.2);
-            color: var(--accent-warning);
-            border: 1px solid rgba(255, 176, 32, 0.3);
-        }
-        
-        .category-safety {
-            background: rgba(244, 99, 99, 0.2);
-            color: var(--accent-danger);
-            border: 1px solid rgba(244, 99, 99, 0.3);
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
+
 </head>
-<body>
+<body id="top">
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <a href="index.html" class="text-2xl font-bold text-gradient">Kykeon Analytics</a>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="text-gray-300 hover:text-white px-3 py-2">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-blue-400 hover:text-blue-300 px-3 py-2 font-medium">More</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Contact</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+        <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="results.html" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">RESULTS</a>
-                    <a href="index.html#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#top" class="btn-secondary">Explore</a>
             </div>
         </div>
     </nav>
@@ -466,46 +344,67 @@
     </section>
     
     <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
+        <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.</p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
             </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
+        <div class="footer-bottom">&copy; 2024 Kykeon Analytics. All rights reserved.</div>
     </footer>
     
-    <script>
+    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
+    <script src="ui.js"></script>
+<script>
         function readArticle(articleId) {
             alert(`Opening article: ${articleId}. This would navigate to the full article page.`);
         }

--- a/contact.html
+++ b/contact.html
@@ -13,190 +13,51 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .card-hover {
-            transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-        }
-        
-        .card-hover:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 20px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, #4A7CE8 100%);
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.3);
-        }
-        
-        .form-input {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.2);
-            border-radius: 8px;
-            padding: 12px 16px;
-            color: var(--text-primary);
-            transition: all 0.3s ease;
-        }
-        
-        .form-input:focus {
-            outline: none;
-            border-color: var(--accent-primary);
-            box-shadow: 0 0 0 3px rgba(91, 140, 255, 0.1);
-        }
-        
-        .contact-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 16px;
-            transition: all 0.3s ease;
-        }
-        
-        .contact-card:hover {
-            border-color: var(--accent-primary);
-            box-shadow: 0 10px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .department-card {
-            background: var(--bg-secondary);
-            border-left: 4px solid var(--accent-primary);
-            border-radius: 8px;
-            padding: 1.5rem;
-            transition: all 0.3s ease;
-        }
-        
-        .department-card:hover {
-            background: rgba(91, 140, 255, 0.05);
-            transform: translateX(4px);
-        }
-        
-        .sms-form {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(47, 203, 137, 0.1);
-            border-radius: 16px;
-            padding: 2rem;
-        }
-        
-        .alert-level {
-            display: inline-flex;
-            align-items: center;
-            padding: 4px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .alert-critical {
-            background: rgba(244, 99, 99, 0.2);
-            color: var(--accent-danger);
-            border: 1px solid rgba(244, 99, 99, 0.3);
-        }
-        
-        .alert-warning {
-            background: rgba(255, 176, 32, 0.2);
-            color: var(--accent-warning);
-            border: 1px solid rgba(255, 176, 32, 0.3);
-        }
-        
-        .alert-info {
-            background: rgba(91, 140, 255, 0.2);
-            color: var(--accent-primary);
-            border: 1px solid rgba(91, 140, 255, 0.3);
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
+
 </head>
-<body>
+<body id="top">
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <a href="index.html" class="text-2xl font-bold text-gradient">Kykeon Analytics</a>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="text-gray-300 hover:text-white px-3 py-2">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">More</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-blue-400 hover:text-blue-300 px-3 py-2 font-medium">Contact</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+        <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="results.html" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">RESULTS</a>
-                    <a href="index.html#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#top" class="btn-secondary">Explore</a>
             </div>
         </div>
     </nav>
@@ -572,46 +433,67 @@
     </section>
     
     <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
+        <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.</p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
             </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
+        <div class="footer-bottom">&copy; 2024 Kykeon Analytics. All rights reserved.</div>
     </footer>
     
-    <script>
+    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
+    <script src="ui.js"></script>
+<script>
         function scrollToSMS() {
             document.getElementById('sms-alerts').scrollIntoView({ behavior: 'smooth' });
         }

--- a/faq.html
+++ b/faq.html
@@ -13,193 +13,51 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .faq-item {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 12px;
-            margin-bottom: 1rem;
-            overflow: hidden;
-            transition: all 0.3s ease;
-        }
-        
-        .faq-item:hover {
-            border-color: var(--accent-primary);
-        }
-        
-        .faq-question {
-            padding: 1.5rem;
-            cursor: pointer;
-            display: flex;
-            justify-content: between;
-            align-items: center;
-            background: transparent;
-            border: none;
-            width: 100%;
-            text-align: left;
-            color: var(--text-primary);
-            font-size: 1.1rem;
-            font-weight: 600;
-        }
-        
-        .faq-question:hover {
-            background: rgba(91, 140, 255, 0.05);
-        }
-        
-        .faq-answer {
-            padding: 0 1.5rem 1.5rem;
-            color: var(--text-secondary);
-            line-height: 1.7;
-            display: none;
-        }
-        
-        .faq-answer.active {
-            display: block;
-        }
-        
-        .faq-icon {
-            transition: transform 0.3s ease;
-            color: var(--accent-primary);
-        }
-        
-        .faq-icon.rotated {
-            transform: rotate(180deg);
-        }
-        
-        .search-bar {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.2);
-            border-radius: 12px;
-            padding: 1rem 1.5rem;
-            color: var(--text-primary);
-            font-size: 1.1rem;
-            width: 100%;
-            transition: all 0.3s ease;
-        }
-        
-        .search-bar:focus {
-            outline: none;
-            border-color: var(--accent-primary);
-            box-shadow: 0 0 0 3px rgba(91, 140, 255, 0.1);
-        }
-        
-        .category-filter {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-            margin-bottom: 2rem;
-        }
-        
-        .filter-btn {
-            padding: 0.5rem 1rem;
-            border-radius: 20px;
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.2);
-            color: var(--text-secondary);
-            cursor: pointer;
-            transition: all 0.3s ease;
-            font-size: 0.9rem;
-        }
-        
-        .filter-btn.active {
-            background: var(--accent-primary);
-            color: white;
-            border-color: var(--accent-primary);
-        }
-        
-        .filter-btn:hover:not(.active) {
-            background: rgba(91, 140, 255, 0.1);
-            color: var(--text-primary);
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
+
 </head>
-<body>
+<body id="top">
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <a href="index.html" class="text-2xl font-bold text-gradient">Kykeon Analytics</a>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="text-gray-300 hover:text-white px-3 py-2">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-blue-400 hover:text-blue-300 px-3 py-2 font-medium">More</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Contact</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+        <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="results.html" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">RESULTS</a>
-                    <a href="index.html#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#top" class="btn-secondary">Explore</a>
             </div>
         </div>
     </nav>
@@ -522,46 +380,67 @@
     </section>
     
     <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
+        <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.</p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
             </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
+        <div class="footer-bottom">&copy; 2024 Kykeon Analytics. All rights reserved.</div>
     </footer>
     
-    <script>
+    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
+    <script src="ui.js"></script>
+<script>
         function toggleFAQ(element) {
             const faqItem = element.parentElement;
             const answer = faqItem.querySelector('.faq-answer');

--- a/index.html
+++ b/index.html
@@ -5,495 +5,321 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kykeon Analytics - Harm Reduction Analysis</title>
     <meta name="description" content="Kykeon Analytics provides analytical solutions for harm reduction in the field of newly emerging chemical entities. We offer substance testing, spectral libraries, and market monitoring.">
-    
-    <!-- Fonts -->
+
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    
-    <!-- Core Libraries -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/typed.js/2.0.12/typed.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/js/splide.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.min.js"></script>
-    
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-            overflow-x: hidden;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .bg-gradient-primary {
-            background: linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .card-hover {
-            transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-        }
-        
-        .card-hover:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 20px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, #4A7CE8 100%);
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.3);
-        }
-        
-        .data-table {
-            background: var(--bg-secondary);
-            border-radius: 12px;
-            overflow: hidden;
-            border: 1px solid rgba(91, 140, 255, 0.1);
-        }
-        
-        .table-header {
-            background: rgba(91, 140, 255, 0.1);
-            border-bottom: 1px solid rgba(91, 140, 255, 0.2);
-        }
-        
-        .table-row:hover {
-            background: rgba(91, 140, 255, 0.05);
-        }
-        
-        .risk-high { color: var(--accent-danger); }
-        .risk-medium { color: var(--accent-warning); }
-        .risk-low { color: var(--accent-success); }
-        
-        #particles-container {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: -1;
-            opacity: 0.3;
-        }
-        
-        .hero-content {
-            position: relative;
-            z-index: 10;
-        }
-        
-        .nav-link {
-            position: relative;
-            transition: all 0.3s ease;
-        }
-        
-        .nav-link:hover {
-            color: var(--accent-primary);
-        }
-        
-        .nav-link::after {
-            content: '';
-            position: absolute;
-            bottom: -4px;
-            left: 0;
-            width: 0;
-            height: 2px;
-            background: var(--accent-primary);
-            transition: width 0.3s ease;
-        }
-        
-        .nav-link:hover::after {
-            width: 100%;
-        }
-        
-        .dropdown {
-            opacity: 0;
-            visibility: hidden;
-            transform: translateY(-10px);
-            transition: all 0.3s ease;
-        }
-        
-        .dropdown.active {
-            opacity: 1;
-            visibility: visible;
-            transform: translateY(0);
-        }
-        
-        .filter-input {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.2);
-            border-radius: 8px;
-            padding: 12px 16px;
-            color: var(--text-primary);
-            transition: all 0.3s ease;
-        }
-        
-        .filter-input:focus {
-            outline: none;
-            border-color: var(--accent-primary);
-            box-shadow: 0 0 0 3px rgba(91, 140, 255, 0.1);
-        }
-        
-        .status-badge {
-            padding: 4px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .status-danger {
-            background: rgba(244, 99, 99, 0.2);
-            color: var(--accent-danger);
-            border: 1px solid rgba(244, 99, 99, 0.3);
-        }
-        
-        .status-warning {
-            background: rgba(255, 176, 32, 0.2);
-            color: var(--accent-warning);
-            border: 1px solid rgba(255, 176, 32, 0.3);
-        }
-        
-        .status-safe {
-            background: rgba(47, 203, 137, 0.2);
-            color: var(--accent-success);
-            border: 1px solid rgba(47, 203, 137, 0.3);
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-    <!-- Particle Background -->
+<body id="top">
     <div id="particles-container"></div>
-    
-    <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <div class="text-2xl font-bold text-gradient">Kykeon Analytics</div>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="nav-link text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="dropdown absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="nav-link text-gray-300 hover:text-white px-3 py-2">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="nav-link text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="dropdown absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="nav-link text-gray-300 hover:text-white px-3 py-2">More</button>
-                        <div class="dropdown absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="nav-link text-gray-300 hover:text-white px-3 py-2">Contact</button>
-                        <div class="dropdown absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+
+    <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="results.html" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">RESULTS</a>
-                    <a href="#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#warnings" class="btn-secondary">Warnings</a>
             </div>
         </div>
     </nav>
-    
-    <!-- Hero Section -->
-    <section class="relative min-h-screen flex items-center justify-center pt-16">
-        <div class="absolute inset-0 bg-gradient-to-br from-gray-900 via-gray-900 to-blue-900/20"></div>
-        <div class="absolute inset-0">
-            <img src="resources/hero-lab.png" alt="Modern analytical chemistry laboratory" class="w-full h-full object-cover opacity-30">
-        </div>
-        
-        <div class="hero-content max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <h1 class="text-5xl md:text-7xl font-bold mb-6">
-                <span class="text-gradient" id="typed-headline"></span>
-            </h1>
-            
-            <p class="text-xl md:text-2xl text-gray-300 mb-8 max-w-4xl mx-auto leading-relaxed">
-                Kykeon Analytics is a public service initiative that provides analytical solutions for harm reduction in the field of newly emerging chemical entities. We work with users and organizations to create Spectral Libraries that provide researchers and organizations with the tools they need to save lives and advance science, free of charge.
-            </p>
-            
-            <div class="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-                <a href="services-users.html" class="btn-primary px-8 py-4 rounded-lg text-white font-semibold text-lg">
-                    Get Testing Services
-                </a>
-                <a href="services-organizations.html" class="border-2 border-blue-500 text-blue-500 hover:bg-blue-500 hover:text-white px-8 py-4 rounded-lg font-semibold text-lg transition-colors">
-                    Access Spectral Libraries
-                </a>
-            </div>
-            
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
-                <div class="card-hover bg-gray-800/50 backdrop-blur-sm p-6 rounded-xl border border-gray-700">
-                    <div class="text-3xl mb-4">🔬</div>
-                    <h3 class="text-xl font-semibold mb-3">For Users</h3>
-                    <p class="text-gray-300">Substance analysis service with NMR, LC-MS, and FTIR techniques for competitive prices.</p>
-                </div>
-                
-                <div class="card-hover bg-gray-800/50 backdrop-blur-sm p-6 rounded-xl border border-gray-700">
-                    <div class="text-3xl mb-4">🏢</div>
-                    <h3 class="text-xl font-semibold mb-3">For Organizations</h3>
-                    <p class="text-gray-300">Spectral libraries, training, and tools for harm reduction workers and researchers.</p>
-                </div>
-                
-                <div class="card-hover bg-gray-800/50 backdrop-blur-sm p-6 rounded-xl border border-gray-700">
-                    <div class="text-3xl mb-4">🛡️</div>
-                    <h3 class="text-xl font-semibold mb-3">For Community</h3>
-                    <p class="text-gray-300">Market monitoring and anonymous testing to detect adulteration and novel substances.</p>
-                </div>
-            </div>
-        </div>
-    </section>
-    
-    <!-- Warnings Section -->
-    <section id="warnings" class="py-20 bg-gray-900/50">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="text-center mb-12">
-                <h2 class="text-4xl font-bold mb-4">Recent Warnings</h2>
-                <p class="text-xl text-gray-300 max-w-3xl mx-auto">
-                    Our ongoing market monitoring detects and analyzes new substances, adding them to spectral databases. 
-                    We test unscheduled chemical entities to find potential adulterants, promoting public safety.
-                </p>
-            </div>
-            
-            <!-- Filters -->
-            <div class="mb-8 flex flex-wrap gap-4">
-                <input type="text" id="substanceFilter" placeholder="Filter by substance name..." class="filter-input flex-1 min-w-0">
-                <select id="riskFilter" class="filter-input">
-                    <option value="">All Risk Levels</option>
-                    <option value="high">High Risk</option>
-                    <option value="medium">Medium Risk</option>
-                    <option value="low">Low Risk</option>
-                </select>
-                <input type="date" id="dateFilter" class="filter-input">
-                <button onclick="clearFilters()" class="px-6 py-3 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors">Clear</button>
-            </div>
-            
-            <!-- Data Table -->
-            <div class="data-table">
-                <div class="table-header p-4">
-                    <div class="grid grid-cols-12 gap-4 text-sm font-semibold text-gray-300">
-                        <div class="col-span-3">Substance</div>
-                        <div class="col-span-2">Source</div>
-                        <div class="col-span-2">Date</div>
-                        <div class="col-span-3">Analysis</div>
-                        <div class="col-span-2">Safety</div>
+
+    <main>
+        <section class="hero-section">
+            <div class="hero-grid">
+                <div class="hero-intro">
+                    <span class="category-badge category-research">Public service laboratory</span>
+                    <h1>
+                        <span class="text-gradient" id="typed-headline"></span>
+                    </h1>
+                    <p>
+                        Kykeon Analytics is a public service initiative that provides analytical solutions for harm reduction in the field of newly emerging chemical entities. We work with users and organizations to create Spectral Libraries that provide researchers and organizations with the tools they need to save lives and advance science, free of charge.
+                    </p>
+                    <div class="hero-cta">
+                        <a href="services-users.html" class="btn-primary">Get Testing Services</a>
+                        <a href="services-organizations.html" class="btn-secondary">Access Spectral Libraries</a>
+                        <a href="market-monitoring.html" class="btn-secondary">Market Monitoring</a>
+                    </div>
+                    <div class="stat-tiles">
+                        <div class="stat-tile">
+                            <strong>ISO-Calibrated</strong>
+                            <span class="text-sm text-gray-300">NMR, LC-MS, and FTIR instrumentation operated in Catalonia.</span>
+                        </div>
+                        <div class="stat-tile">
+                            <strong>Open Science</strong>
+                            <span class="text-sm text-gray-300">Creative Commons licensed spectral libraries and transparent reporting.</span>
+                        </div>
+                        <div class="stat-tile">
+                            <strong>Safety First</strong>
+                            <span class="text-sm text-gray-300">Market monitoring and rapid warnings to protect the community.</span>
+                        </div>
                     </div>
                 </div>
-                
-                <div id="warningsTable" class="divide-y divide-gray-700">
-                    <!-- Table rows will be populated by JavaScript -->
+
+                <div class="hero-stats">
+                    <div class="hero-card">
+                        <h3>For Users</h3>
+                        <p>Substance analysis service with NMR, LC-MS, and FTIR techniques for competitive prices.</p>
+                        <ul class="space-y-2 text-sm text-gray-300 mt-4">
+                            <li>• Qualitative testing from €20</li>
+                            <li>• Full quantitative analysis from €80</li>
+                            <li>• Plant and mushroom testing €100</li>
+                            <li>• Multiple payment methods accepted</li>
+                        </ul>
+                    </div>
+                    <div class="hero-card">
+                        <h3>For Organizations</h3>
+                        <p>Spectral libraries, training, and tools for harm reduction workers and researchers.</p>
+                        <ul class="space-y-2 text-sm text-gray-300 mt-4">
+                            <li>• Free spectral libraries (FTIR &amp; NMR)</li>
+                            <li>• In-person and online training</li>
+                            <li>• Equipment advisory services</li>
+                            <li>• Creative Commons licensed data</li>
+                        </ul>
+                    </div>
+                    <div class="hero-card">
+                        <h3>For Community</h3>
+                        <p>Market monitoring and anonymous testing to detect adulteration and novel substances.</p>
+                        <ul class="space-y-2 text-sm text-gray-300 mt-4">
+                            <li>• Anonymous vendor monitoring</li>
+                            <li>• Real-time danger alerts</li>
+                            <li>• Novel substance detection</li>
+                            <li>• Public safety warnings</li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-            
-            <div class="mt-8 text-center">
-                <a href="market-monitoring.html" class="btn-primary px-8 py-4 rounded-lg text-white font-semibold">
-                    View Full Market Monitoring Data
-                </a>
-            </div>
-        </div>
-    </section>
-    
-    <!-- Services Overview -->
-    <section class="py-20">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="text-center mb-16">
-                <h2 class="text-4xl font-bold mb-4">Our Services</h2>
-                <p class="text-xl text-gray-300 max-w-3xl mx-auto">
-                    Comprehensive harm reduction solutions for individuals, organizations, and the community
+        </section>
+
+        <section id="warnings" class="section-shell alt">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <h2 class="section-heading text-gradient">Recent Warnings</h2>
+                <p class="section-subheading">
+                    Our ongoing market monitoring detects and analyzes new substances, adding them to spectral databases.
+                    We test unscheduled chemical entities to find potential adulterants, promoting public safety.
                 </p>
+
+                <div class="mb-10 flex flex-wrap gap-4">
+                    <input type="text" id="substanceFilter" placeholder="Filter by substance name..." class="filter-input flex-1 min-w-0">
+                    <select id="riskFilter" class="filter-input">
+                        <option value="">All Risk Levels</option>
+                        <option value="high">High Risk</option>
+                        <option value="medium">Medium Risk</option>
+                        <option value="low">Low Risk</option>
+                    </select>
+                    <input type="date" id="dateFilter" class="filter-input">
+                    <button onclick="clearFilters()" class="btn-secondary">Clear</button>
+                </div>
+
+                <div class="data-table">
+                    <div class="table-header p-5">
+                        <div class="grid grid-cols-12 gap-4 text-sm font-semibold text-gray-300">
+                            <div class="col-span-3">Substance</div>
+                            <div class="col-span-2">Source</div>
+                            <div class="col-span-2">Date</div>
+                            <div class="col-span-3">Analysis</div>
+                            <div class="col-span-2">Safety</div>
+                        </div>
+                    </div>
+                    <div id="warningsTable" class="divide-y divide-gray-800"></div>
+                </div>
+
+                <div class="text-center mt-12">
+                    <a href="market-monitoring.html" class="btn-primary">View Full Market Monitoring Data</a>
+                </div>
             </div>
-            
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                <!-- Individual Users -->
-                <div class="card-hover bg-gradient-to-br from-blue-900/20 to-gray-800 p-8 rounded-2xl border border-blue-500/20">
-                    <div class="text-4xl mb-6">👤</div>
-                    <h3 class="text-2xl font-bold mb-4">For Users</h3>
-                    <p class="text-gray-300 mb-6">
-                        Through NMR, LC-MS and FTIR techniques, we identify and quantify compounds in your sample for competitive prices. 
-                        Detailed reports and spectra provided.
-                    </p>
-                    <ul class="space-y-2 text-sm text-gray-400 mb-6">
-                        <li>• Qualitative testing from €20</li>
-                        <li>• Full quantitative analysis from €80</li>
-                        <li>• Plant and mushroom testing €100</li>
-                        <li>• Multiple payment methods accepted</li>
-                    </ul>
-                    <a href="services-users.html" class="btn-primary w-full py-3 rounded-lg text-center block">
-                        Get Testing Services
-                    </a>
+        </section>
+
+        <section class="section-shell">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <h2 class="section-heading text-gradient">Our Services</h2>
+                <p class="section-subheading">Comprehensive harm reduction solutions for individuals, organizations, and the community.</p>
+
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-10">
+                    <div class="pricing-card">
+                        <div class="text-4xl mb-4">👤</div>
+                        <h3 class="text-2xl font-bold mb-3">For Users</h3>
+                        <p class="text-gray-300 mb-6">
+                            Through NMR, LC-MS and FTIR techniques, we identify and quantify compounds in your sample for competitive prices.
+                            Detailed reports and spectra provided.
+                        </p>
+                        <ul class="space-y-2 text-sm text-gray-400 mb-6">
+                            <li>• Qualitative testing from €20</li>
+                            <li>• Full quantitative analysis from €80</li>
+                            <li>• Plant and mushroom testing €100</li>
+                            <li>• Multiple payment methods accepted</li>
+                        </ul>
+                        <a href="services-users.html" class="btn-primary w-full justify-center">Get Testing Services</a>
+                    </div>
+
+                    <div class="pricing-card featured">
+                        <div class="text-4xl mb-4">🏛️</div>
+                        <h3 class="text-2xl font-bold mb-3">For Organizations</h3>
+                        <p class="text-gray-300 mb-6">
+                            We provide FTIR and NMR spectral libraries free of charge under Creative Commons license.
+                            Training and tools for harm reduction workers.
+                        </p>
+                        <ul class="space-y-2 text-sm text-gray-200 mb-6">
+                            <li>• Free spectral libraries (FTIR &amp; NMR)</li>
+                            <li>• In-person and online training</li>
+                            <li>• Equipment advisory services</li>
+                            <li>• Creative Commons licensed data</li>
+                        </ul>
+                        <a href="services-organizations.html" class="btn-primary w-full justify-center">Access Libraries</a>
+                    </div>
+
+                    <div class="pricing-card">
+                        <div class="text-4xl mb-4">🌍</div>
+                        <h3 class="text-2xl font-bold mb-3">For Community</h3>
+                        <p class="text-gray-300 mb-6">
+                            Anonymous market monitoring to detect adulteration, mislabeling and novel substances.
+                            Publishing warnings when dangerous substances are found.
+                        </p>
+                        <ul class="space-y-2 text-sm text-gray-400 mb-6">
+                            <li>• Anonymous vendor monitoring</li>
+                            <li>• Real-time danger alerts</li>
+                            <li>• Novel substance detection</li>
+                            <li>• Public safety warnings</li>
+                        </ul>
+                        <a href="market-monitoring.html" class="btn-primary w-full justify-center">View Monitoring Data</a>
+                    </div>
                 </div>
-                
-                <!-- Organizations -->
-                <div class="card-hover bg-gradient-to-br from-green-900/20 to-gray-800 p-8 rounded-2xl border border-green-500/20">
-                    <div class="text-4xl mb-6">🏛️</div>
-                    <h3 class="text-2xl font-bold mb-4">For Organizations</h3>
-                    <p class="text-gray-300 mb-6">
-                        We provide FTIR and NMR spectral libraries free of charge under Creative Commons license. 
-                        Training and tools for harm reduction workers.
-                    </p>
-                    <ul class="space-y-2 text-sm text-gray-400 mb-6">
-                        <li>• Free spectral libraries (FTIR & NMR)</li>
-                        <li>• In-person and online training</li>
-                        <li>• Equipment advisory services</li>
-                        <li>• Creative Commons licensed data</li>
-                    </ul>
-                    <a href="services-organizations.html" class="bg-green-600 hover:bg-green-700 w-full py-3 rounded-lg text-center block transition-colors">
-                        Access Libraries
-                    </a>
+            </div>
+        </section>
+
+        <section class="section-shell alt">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <h2 class="section-heading text-gradient">Scientific Excellence</h2>
+                <p class="section-subheading">State-of-the-art equipment and methodologies.</p>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                    <div class="stats-card text-center">
+                        <div class="text-4xl mb-3">🔬</div>
+                        <h3 class="text-xl font-semibold mb-2">NMR Spectroscopy</h3>
+                        <p class="text-gray-400 text-sm">Nanalysis Pro100MHz for 1D and 2D experiments.</p>
+                    </div>
+                    <div class="stats-card text-center">
+                        <div class="text-4xl mb-3">⚗️</div>
+                        <h3 class="text-xl font-semibold mb-2">LC-MS Analysis</h3>
+                        <p class="text-gray-400 text-sm">Agilent triple-quadrupole LC-MS system.</p>
+                    </div>
+                    <div class="stats-card text-center">
+                        <div class="text-4xl mb-3">📡</div>
+                        <h3 class="text-xl font-semibold mb-2">FTIR Spectrometry</h3>
+                        <p class="text-gray-400 text-sm">Nicolet IS5 and IS10 FTIR spectrometers.</p>
+                    </div>
+                    <div class="stats-card text-center">
+                        <div class="text-4xl mb-3">🔒</div>
+                        <h3 class="text-xl font-semibold mb-2">Anonymous Testing</h3>
+                        <p class="text-gray-400 text-sm">No vendor collaboration, pure research.</p>
+                    </div>
                 </div>
-                
-                <!-- Community -->
-                <div class="card-hover bg-gradient-to-br from-purple-900/20 to-gray-800 p-8 rounded-2xl border border-purple-500/20">
-                    <div class="text-4xl mb-6">🌍</div>
-                    <h3 class="text-2xl font-bold mb-4">For Community</h3>
-                    <p class="text-gray-300 mb-6">
-                        Anonymous market monitoring to detect adulteration, mislabeling and novel substances. 
-                        Publishing warnings when dangerous substances are found.
-                    </p>
-                    <ul class="space-y-2 text-sm text-gray-400 mb-6">
-                        <li>• Anonymous vendor monitoring</li>
-                        <li>• Real-time danger alerts</li>
-                        <li>• Novel substance detection</li>
-                        <li>• Public safety warnings</li>
-                    </ul>
-                    <a href="market-monitoring.html" class="bg-purple-600 hover:bg-purple-700 w-full py-3 rounded-lg text-center block transition-colors">
-                        View Monitoring Data
-                    </a>
-                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">
+                    A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
+                </p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
-    </section>
-    
-    <!-- Trust Signals -->
-    <section class="py-20 bg-gray-900/30">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="text-center mb-16">
-                <h2 class="text-4xl font-bold mb-4">Scientific Excellence</h2>
-                <p class="text-xl text-gray-300">State-of-the-art equipment and methodologies</p>
-            </div>
-            
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-                <div class="text-center">
-                    <div class="text-4xl mb-4">🔬</div>
-                    <h3 class="text-xl font-semibold mb-2">NMR Spectroscopy</h3>
-                    <p class="text-gray-400 text-sm">Nanalysis Pro100MHz for 1D and 2D experiments</p>
-                </div>
-                
-                <div class="text-center">
-                    <div class="text-4xl mb-4">⚗️</div>
-                    <h3 class="text-xl font-semibold mb-2">LC-MS Analysis</h3>
-                    <p class="text-gray-400 text-sm">Agilent triple-quadrupole LC-MS system</p>
-                </div>
-                
-                <div class="text-center">
-                    <div class="text-4xl mb-4">📡</div>
-                    <h3 class="text-xl font-semibold mb-2">FTIR Spectrometry</h3>
-                    <p class="text-gray-400 text-sm">Nicolet IS5 and IS10 FTIR spectrometers</p>
-                </div>
-                
-                <div class="text-center">
-                    <div class="text-4xl mb-4">🔒</div>
-                    <h3 class="text-xl font-semibold mb-2">Anonymous Testing</h3>
-                    <p class="text-gray-400 text-sm">No vendor collaboration, pure research</p>
-                </div>
-            </div>
-        </div>
-    </section>
-    
-    <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
-            </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
-            </div>
+        <div class="footer-bottom">
+            &copy; 2024 Kykeon Analytics. All rights reserved.
         </div>
     </footer>
-    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
     <script src="main.js"></script>
+    <script src="ui.js"></script>
 </body>
 </html>

--- a/legal.html
+++ b/legal.html
@@ -13,199 +13,51 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, #4A7CE8 100%);
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.3);
-        }
-        
-        .legal-section {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 16px;
-            padding: 2rem;
-            margin-bottom: 2rem;
-            transition: all 0.3s ease;
-        }
-        
-        .legal-section:hover {
-            border-color: var(--accent-primary);
-            box-shadow: 0 10px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .legal-nav {
-            position: sticky;
-            top: 100px;
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 12px;
-            padding: 1.5rem;
-        }
-        
-        .legal-nav a {
-            display: block;
-            padding: 0.75rem 1rem;
-            color: var(--text-secondary);
-            text-decoration: none;
-            border-radius: 8px;
-            transition: all 0.3s ease;
-        }
-        
-        .legal-nav a:hover {
-            background: rgba(91, 140, 255, 0.1);
-            color: var(--accent-primary);
-        }
-        
-        .legal-nav a.active {
-            background: var(--accent-primary);
-            color: white;
-        }
-        
-        .cookie-table {
-            background: var(--bg-secondary);
-            border-radius: 12px;
-            overflow: hidden;
-            border: 1px solid rgba(91, 140, 255, 0.1);
-        }
-        
-        .cookie-table th {
-            background: rgba(91, 140, 255, 0.1);
-            padding: 1rem;
-            text-align: left;
-            font-weight: 600;
-        }
-        
-        .cookie-table td {
-            padding: 1rem;
-            border-bottom: 1px solid rgba(91, 140, 255, 0.1);
-        }
-        
-        .cookie-table tr:last-child td {
-            border-bottom: none;
-        }
-        
-        .cookie-category {
-            display: inline-flex;
-            align-items: center;
-            padding: 4px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .cookie-essential {
-            background: rgba(47, 203, 137, 0.2);
-            color: var(--accent-success);
-            border: 1px solid rgba(47, 203, 137, 0.3);
-        }
-        
-        .cookie-analytics {
-            background: rgba(91, 140, 255, 0.2);
-            color: var(--accent-primary);
-            border: 1px solid rgba(91, 140, 255, 0.3);
-        }
-        
-        .cookie-marketing {
-            background: rgba(255, 176, 32, 0.2);
-            color: var(--accent-warning);
-            border: 1px solid rgba(255, 176, 32, 0.3);
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
+
 </head>
-<body>
+<body id="top">
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <a href="index.html" class="text-2xl font-bold text-gradient">Kykeon Analytics</a>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="text-gray-300 hover:text-white px-3 py-2">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">More</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Contact</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+        <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="results.html" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">RESULTS</a>
-                    <a href="index.html#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#top" class="btn-secondary">Explore</a>
             </div>
         </div>
     </nav>
@@ -672,46 +524,67 @@
     </section>
     
     <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
+        <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.</p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
             </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
+        <div class="footer-bottom">&copy; 2024 Kykeon Analytics. All rights reserved.</div>
     </footer>
     
-    <script>
+    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
+    <script src="ui.js"></script>
+<script>
         function showSection(sectionName) {
             // Hide all sections
             document.querySelectorAll('.legal-content').forEach(section => {

--- a/market-monitoring.html
+++ b/market-monitoring.html
@@ -14,257 +14,51 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
     
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .card-hover {
-            transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-        }
-        
-        .card-hover:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 20px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, #4A7CE8 100%);
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.3);
-        }
-        
-        .methodology-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 16px;
-            transition: all 0.3s ease;
-        }
-        
-        .methodology-card:hover {
-            border-color: var(--accent-primary);
-            box-shadow: 0 10px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .dashboard-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(47, 203, 137, 0.1);
-            border-radius: 12px;
-            transition: all 0.3s ease;
-        }
-        
-        .dashboard-card:hover {
-            border-color: var(--accent-success);
-            box-shadow: 0 5px 20px rgba(47, 203, 137, 0.1);
-        }
-        
-        .timeline-item {
-            position: relative;
-            padding-left: 2rem;
-            margin-bottom: 2rem;
-        }
-        
-        .timeline-item::before {
-            content: '';
-            position: absolute;
-            left: 0;
-            top: 0.5rem;
-            width: 12px;
-            height: 12px;
-            background: var(--accent-primary);
-            border-radius: 50%;
-        }
-        
-        .timeline-item::after {
-            content: '';
-            position: absolute;
-            left: 5px;
-            top: 1.5rem;
-            width: 2px;
-            height: calc(100% + 1rem);
-            background: rgba(91, 140, 255, 0.2);
-        }
-        
-        .timeline-item:last-child::after {
-            display: none;
-        }
-        
-        .risk-indicator {
-            display: inline-block;
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            margin-right: 8px;
-        }
-        
-        .risk-high { background-color: var(--accent-danger); }
-        .risk-medium { background-color: var(--accent-warning); }
-        .risk-low { background-color: var(--accent-success); }
-        
-        .chart-container {
-            background: var(--bg-secondary);
-            border-radius: 12px;
-            padding: 1.5rem;
-            border: 1px solid rgba(91, 140, 255, 0.1);
-        }
-        
-        .filter-tabs {
-            display: flex;
-            background: var(--bg-secondary);
-            border-radius: 8px;
-            padding: 4px;
-            margin-bottom: 2rem;
-        }
-        
-        .filter-tab {
-            flex: 1;
-            padding: 12px 24px;
-            text-align: center;
-            border-radius: 6px;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            color: var(--text-secondary);
-        }
-        
-        .filter-tab.active {
-            background: var(--accent-primary);
-            color: white;
-        }
-        
-        .filter-tab:hover:not(.active) {
-            background: rgba(91, 140, 255, 0.1);
-            color: var(--text-primary);
-        }
-        
-        .alert-badge {
-            display: inline-flex;
-            align-items: center;
-            padding: 4px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .alert-critical {
-            background: rgba(244, 99, 99, 0.2);
-            color: var(--accent-danger);
-            border: 1px solid rgba(244, 99, 99, 0.3);
-        }
-        
-        .alert-warning {
-            background: rgba(255, 176, 32, 0.2);
-            color: var(--accent-warning);
-            border: 1px solid rgba(255, 176, 32, 0.3);
-        }
-        
-        .alert-info {
-            background: rgba(91, 140, 255, 0.2);
-            color: var(--accent-primary);
-            border: 1px solid rgba(91, 140, 255, 0.3);
-        }
-        
-        .geographic-map {
-            background: var(--bg-secondary);
-            border-radius: 12px;
-            padding: 2rem;
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            min-height: 400px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--text-secondary);
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
+
 </head>
-<body>
+<body id="top">
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <a href="index.html" class="text-2xl font-bold text-gradient">Kykeon Analytics</a>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="text-gray-300 hover:text-white px-3 py-2">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">More</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Contact</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+        <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="results.html" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">RESULTS</a>
-                    <a href="index.html#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#top" class="btn-secondary">Explore</a>
             </div>
         </div>
     </nav>
@@ -827,46 +621,67 @@
     </section>
     
     <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
+        <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.</p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
             </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
+        <div class="footer-bottom">&copy; 2024 Kykeon Analytics. All rights reserved.</div>
     </footer>
     
-    <script>
+    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
+    <script src="ui.js"></script>
+<script>
         // Dashboard functionality
         function switchDashboard(tab) {
             // Hide all dashboard sections

--- a/results.html
+++ b/results.html
@@ -14,266 +14,51 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
     
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .card-hover {
-            transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-        }
-        
-        .card-hover:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 20px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, #4A7CE8 100%);
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.3);
-        }
-        
-        .form-input {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.2);
-            border-radius: 8px;
-            padding: 12px 16px;
-            color: var(--text-primary);
-            transition: all 0.3s ease;
-        }
-        
-        .form-input:focus {
-            outline: none;
-            border-color: var(--accent-primary);
-            box-shadow: 0 0 0 3px rgba(91, 140, 255, 0.1);
-        }
-        
-        .result-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 16px;
-            transition: all 0.3s ease;
-        }
-        
-        .result-card:hover {
-            border-color: var(--accent-primary);
-            box-shadow: 0 10px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .status-badge {
-            display: inline-flex;
-            align-items: center;
-            padding: 4px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .status-complete {
-            background: rgba(47, 203, 137, 0.2);
-            color: var(--accent-success);
-            border: 1px solid rgba(47, 203, 137, 0.3);
-        }
-        
-        .status-pending {
-            background: rgba(255, 176, 32, 0.2);
-            color: var(--accent-warning);
-            border: 1px solid rgba(255, 176, 32, 0.3);
-        }
-        
-        .status-processing {
-            background: rgba(91, 140, 255, 0.2);
-            color: var(--accent-primary);
-            border: 1px solid rgba(91, 140, 255, 0.3);
-        }
-        
-        .authentication-panel {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 16px;
-            padding: 2rem;
-            transition: all 0.3s ease;
-        }
-        
-        .authentication-panel:hover {
-            border-color: var(--accent-primary);
-        }
-        
-        .qr-code {
-            width: 120px;
-            height: 120px;
-            background: white;
-            border-radius: 8px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: black;
-            font-size: 12px;
-            font-weight: bold;
-        }
-        
-        .spectrum-viewer {
-            background: var(--bg-secondary);
-            border-radius: 12px;
-            padding: 1.5rem;
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            min-height: 300px;
-        }
-        
-        .tab-button {
-            padding: 12px 24px;
-            border-radius: 8px;
-            background: transparent;
-            border: 1px solid rgba(91, 140, 255, 0.2);
-            color: var(--text-secondary);
-            cursor: pointer;
-            transition: all 0.3s ease;
-        }
-        
-        .tab-button.active {
-            background: var(--accent-primary);
-            color: white;
-            border-color: var(--accent-primary);
-        }
-        
-        .tab-button:hover:not(.active) {
-            background: rgba(91, 140, 255, 0.1);
-            color: var(--text-primary);
-        }
-        
-        .modal {
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.8);
-            z-index: 1000;
-            backdrop-filter: blur(10px);
-        }
-        
-        .modal.active {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        
-        .modal-content {
-            background: var(--bg-secondary);
-            border-radius: 16px;
-            padding: 2rem;
-            max-width: 600px;
-            width: 90%;
-            max-height: 80vh;
-            overflow-y: auto;
-            border: 1px solid rgba(91, 140, 255, 0.2);
-        }
-        
-        .share-option {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 12px;
-            padding: 1rem;
-            cursor: pointer;
-            transition: all 0.3s ease;
-        }
-        
-        .share-option:hover {
-            border-color: var(--accent-primary);
-            background: rgba(91, 140, 255, 0.05);
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
+
 </head>
-<body>
+<body id="top">
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <a href="index.html" class="text-2xl font-bold text-gradient">Kykeon Analytics</a>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="text-blue-400 hover:text-blue-300 px-3 py-2 font-medium">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">More</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Contact</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+        <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="index.html#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#top" class="btn-secondary">Explore</a>
             </div>
         </div>
     </nav>
@@ -832,46 +617,67 @@
     </div>
     
     <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
+        <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.</p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
             </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
+        <div class="footer-bottom">&copy; 2024 Kykeon Analytics. All rights reserved.</div>
     </footer>
     
-    <script>
+    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
+    <script src="ui.js"></script>
+<script>
         // Results lookup functionality
         function lookupResults(event) {
             event.preventDefault();

--- a/services-organizations.html
+++ b/services-organizations.html
@@ -14,236 +14,51 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
     
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .card-hover {
-            transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-        }
-        
-        .card-hover:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 20px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, #4A7CE8 100%);
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.3);
-        }
-        
-        .form-input {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.2);
-            border-radius: 8px;
-            padding: 12px 16px;
-            color: var(--text-primary);
-            transition: all 0.3s ease;
-        }
-        
-        .form-input:focus {
-            outline: none;
-            border-color: var(--accent-primary);
-            box-shadow: 0 0 0 3px rgba(91, 140, 255, 0.1);
-        }
-        
-        .library-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 16px;
-            transition: all 0.3s ease;
-        }
-        
-        .library-card:hover {
-            border-color: var(--accent-primary);
-            box-shadow: 0 10px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .training-module {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(47, 203, 137, 0.1);
-            border-radius: 12px;
-            transition: all 0.3s ease;
-        }
-        
-        .training-module:hover {
-            border-color: var(--accent-success);
-            box-shadow: 0 5px 20px rgba(47, 203, 137, 0.1);
-        }
-        
-        .progress-bar {
-            background: var(--bg-secondary);
-            border-radius: 10px;
-            overflow: hidden;
-            height: 8px;
-        }
-        
-        .progress-fill {
-            background: linear-gradient(90deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            height: 100%;
-            transition: width 0.3s ease;
-        }
-        
-        .modal {
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.8);
-            z-index: 1000;
-            backdrop-filter: blur(10px);
-        }
-        
-        .modal.active {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        
-        .modal-content {
-            background: var(--bg-secondary);
-            border-radius: 16px;
-            padding: 2rem;
-            max-width: 500px;
-            width: 90%;
-            max-height: 80vh;
-            overflow-y: auto;
-            border: 1px solid rgba(91, 140, 255, 0.2);
-        }
-        
-        .search-bar {
-            position: relative;
-        }
-        
-        .search-results {
-            position: absolute;
-            top: 100%;
-            left: 0;
-            right: 0;
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.2);
-            border-radius: 8px;
-            max-height: 300px;
-            overflow-y: auto;
-            z-index: 100;
-            display: none;
-        }
-        
-        .search-result-item {
-            padding: 12px 16px;
-            border-bottom: 1px solid rgba(91, 140, 255, 0.1);
-            cursor: pointer;
-            transition: background 0.2s ease;
-        }
-        
-        .search-result-item:hover {
-            background: rgba(91, 140, 255, 0.1);
-        }
-        
-        .equipment-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(255, 176, 32, 0.1);
-            border-radius: 12px;
-            transition: all 0.3s ease;
-        }
-        
-        .equipment-card:hover {
-            border-color: var(--accent-warning);
-            box-shadow: 0 5px 20px rgba(255, 176, 32, 0.1);
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
+
 </head>
-<body>
+<body id="top">
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <a href="index.html" class="text-2xl font-bold text-gradient">Kykeon Analytics</a>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="text-gray-300 hover:text-white px-3 py-2">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">More</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Contact</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+        <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="results.html" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">RESULTS</a>
-                    <a href="index.html#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#top" class="btn-secondary">Explore</a>
             </div>
         </div>
     </nav>
@@ -689,46 +504,67 @@
     </div>
     
     <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
+        <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.</p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
             </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
+        <div class="footer-bottom">&copy; 2024 Kykeon Analytics. All rights reserved.</div>
     </footer>
     
-    <script>
+    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
+    <script src="ui.js"></script>
+<script>
         // Library data
         const libraryData = {
             ftir: {

--- a/services-users.html
+++ b/services-users.html
@@ -14,209 +14,51 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js"></script>
     
-    <style>
-        :root {
-            --bg-primary: #0B0D10;
-            --bg-secondary: #1A1D23;
-            --text-primary: #FFFFFF;
-            --text-secondary: #A0AEC0;
-            --accent-primary: #5B8CFF;
-            --accent-success: #2FCB89;
-            --accent-warning: #FFB020;
-            --accent-danger: #F46363;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            line-height: 1.6;
-        }
-        
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        
-        .text-gradient {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-success) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .card-hover {
-            transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-        }
-        
-        .card-hover:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 20px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-primary) 0%, #4A7CE8 100%);
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 10px 30px rgba(91, 140, 255, 0.3);
-        }
-        
-        .pricing-card {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.1);
-            border-radius: 16px;
-            transition: all 0.3s ease;
-        }
-        
-        .pricing-card:hover {
-            border-color: var(--accent-primary);
-            box-shadow: 0 10px 40px rgba(91, 140, 255, 0.1);
-        }
-        
-        .pricing-card.featured {
-            border-color: var(--accent-primary);
-            background: linear-gradient(135deg, rgba(91, 140, 255, 0.1) 0%, rgba(47, 203, 137, 0.1) 100%);
-        }
-        
-        .form-input {
-            background: var(--bg-secondary);
-            border: 1px solid rgba(91, 140, 255, 0.2);
-            border-radius: 8px;
-            padding: 12px 16px;
-            color: var(--text-primary);
-            transition: all 0.3s ease;
-        }
-        
-        .form-input:focus {
-            outline: none;
-            border-color: var(--accent-primary);
-            box-shadow: 0 0 0 3px rgba(91, 140, 255, 0.1);
-        }
-        
-        .step-indicator {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin-bottom: 2rem;
-        }
-        
-        .step {
-            width: 40px;
-            height: 40px;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-weight: 600;
-            margin: 0 1rem;
-            position: relative;
-        }
-        
-        .step.active {
-            background: var(--accent-primary);
-            color: white;
-        }
-        
-        .step.completed {
-            background: var(--accent-success);
-            color: white;
-        }
-        
-        .step.inactive {
-            background: var(--bg-secondary);
-            color: var(--text-secondary);
-            border: 2px solid rgba(91, 140, 255, 0.2);
-        }
-        
-        .step-connector {
-            width: 60px;
-            height: 2px;
-            background: rgba(91, 140, 255, 0.2);
-        }
-        
-        .step-connector.completed {
-            background: var(--accent-success);
-        }
-        
-        .payment-method {
-            background: var(--bg-secondary);
-            border: 2px solid rgba(91, 140, 255, 0.1);
-            border-radius: 12px;
-            padding: 1rem;
-            cursor: pointer;
-            transition: all 0.3s ease;
-        }
-        
-        .payment-method:hover {
-            border-color: var(--accent-primary);
-        }
-        
-        .payment-method.selected {
-            border-color: var(--accent-primary);
-            background: rgba(91, 140, 255, 0.1);
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
+
 </head>
-<body>
+<body id="top">
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-md z-50 border-b border-white/10">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <a href="index.html" class="text-2xl font-bold text-gradient">Kykeon Analytics</a>
-                </div>
-                
-                <div class="hidden md:flex items-center space-x-8">
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">What We Do</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Users</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">For Organizations</a>
-                            <a href="market-monitoring.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Market Monitoring</a>
-                        </div>
-                    </div>
-                    
-                    <a href="results.html" class="text-gray-300 hover:text-white px-3 py-2">Results</a>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Services</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="services-users.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Sample Testing</a>
-                            <a href="services-organizations.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Spectral Libraries</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">More</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="about.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">About</a>
-                            <a href="faq.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">FAQ</a>
-                            <a href="blog.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Blog</a>
-                        </div>
-                    </div>
-                    
-                    <div class="relative group">
-                        <button class="text-gray-300 hover:text-white px-3 py-2">Contact</button>
-                        <div class="absolute top-full left-0 mt-2 w-48 bg-gray-900 rounded-lg shadow-lg py-2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300">
-                            <a href="contact.html" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">General Contact</a>
-                            <a href="contact.html#laboratory" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Laboratory</a>
-                            <a href="contact.html#policy" class="block px-4 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-800">Drug Policy</a>
-                        </div>
+        <nav class="global-nav">
+        <div class="nav-container">
+            <a href="index.html" class="brandmark text-gradient">Kykeon Analytics</a>
+            <div class="nav-links hidden md:flex">
+                <div class="relative group">
+                    <button>What We Do</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">For Users</a>
+                        <a href="services-organizations.html">For Organizations</a>
+                        <a href="market-monitoring.html">Market Monitoring</a>
                     </div>
                 </div>
-                
-                <div class="flex items-center space-x-4">
-                    <a href="results.html" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">RESULTS</a>
-                    <a href="index.html#warnings" class="bg-red-600 hover:bg-red-700 px-6 py-2 rounded-lg text-white font-medium transition-colors">WARNINGS</a>
+                <a href="results.html">Results</a>
+                <div class="relative group">
+                    <button>Services</button>
+                    <div class="dropdown">
+                        <a href="services-users.html">Sample Testing</a>
+                        <a href="services-organizations.html">Spectral Libraries</a>
+                    </div>
                 </div>
+                <div class="relative group">
+                    <button>More</button>
+                    <div class="dropdown">
+                        <a href="about.html">About</a>
+                        <a href="faq.html">FAQ</a>
+                        <a href="blog.html">Blog</a>
+                    </div>
+                </div>
+                <div class="relative group">
+                    <button>Contact</button>
+                    <div class="dropdown">
+                        <a href="contact.html">General Contact</a>
+                        <a href="contact.html#laboratory">Laboratory</a>
+                        <a href="contact.html#policy">Drug Policy</a>
+                    </div>
+                </div>
+            </div>
+            <div class="nav-cta">
+                <a href="results.html" class="primary">Results</a>
+                <a href="#top" class="btn-secondary">Explore</a>
             </div>
         </div>
     </nav>
@@ -677,46 +519,67 @@
     </section>
     
     <!-- Footer -->
-    <footer class="bg-black/50 border-t border-gray-800 py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="col-span-2">
-                    <div class="text-2xl font-bold text-gradient mb-4">Kykeon Analytics</div>
-                    <p class="text-gray-400 mb-4">
-                        A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.
-                    </p>
-                    <p class="text-sm text-gray-500">
-                        Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.
-                    </p>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Services</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="services-users.html" class="hover:text-white transition-colors">Sample Testing</a></li>
-                        <li><a href="services-organizations.html" class="hover:text-white transition-colors">Spectral Libraries</a></li>
-                        <li><a href="market-monitoring.html" class="hover:text-white transition-colors">Market Monitoring</a></li>
-                        <li><a href="results.html" class="hover:text-white transition-colors">Results</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="text-lg font-semibold mb-4">Contact</h3>
-                    <ul class="space-y-2 text-gray-400">
-                        <li><a href="mailto:info@kykeonanalytics.com" class="hover:text-white transition-colors">info@kykeonanalytics.com</a></li>
-                        <li><a href="mailto:office@kykeonanalytics.com" class="hover:text-white transition-colors">office@kykeonanalytics.com</a></li>
-                        <li><a href="contact.html" class="hover:text-white transition-colors">Contact Form</a></li>
-                    </ul>
-                </div>
+        <footer class="site-footer">
+        <div class="footer-inner">
+            <div>
+                <div class="brandmark text-gradient mb-4">Kykeon Analytics</div>
+                <p class="footer-meta mb-4">A public service initiative providing analytical solutions for harm reduction in the field of newly emerging chemical entities.</p>
+                <p class="footer-meta">Located in Catalonia, equipped with state-of-the-art analytical chemistry technology.</p>
             </div>
-            
-            <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 Kykeon Analytics. All rights reserved. | <a href="legal.html" class="hover:text-white transition-colors">Privacy Policy & Legal</a></p>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Services</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="services-users.html">Sample Testing</a></li>
+                    <li><a href="services-organizations.html">Spectral Libraries</a></li>
+                    <li><a href="market-monitoring.html">Market Monitoring</a></li>
+                    <li><a href="results.html">Results</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Resources</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="about.html">About</a></li>
+                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="blog.html">Blog</a></li>
+                    <li><a href="legal.html">Privacy &amp; Legal</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold mb-4">Contact</h3>
+                <ul class="space-y-3 footer-meta">
+                    <li><a href="mailto:info@kykeonanalytics.com">info@kykeonanalytics.com</a></li>
+                    <li><a href="mailto:office@kykeonanalytics.com">office@kykeonanalytics.com</a></li>
+                    <li><a href="contact.html">Contact Form</a></li>
+                </ul>
             </div>
         </div>
+        <div class="footer-bottom">&copy; 2024 Kykeon Analytics. All rights reserved.</div>
     </footer>
     
-    <script>
+    
+
+    <div class="chatbot-widget">
+        <div class="chatbot-window" id="chatbotWindow" aria-hidden="true">
+            <div class="chatbot-header">
+                <div>
+                    <h3 class="text-lg font-semibold">Kykeon Virtual Assistant</h3>
+                    <p class="text-sm text-gray-300">Ask anything about our testing, libraries, or warnings.</p>
+                </div>
+                <button class="text-gray-300 hover:text-white" data-chatbot-close>&times;</button>
+            </div>
+            <div class="chatbot-body">
+                <div class="chatbot-message">This assistant can guide you through our services and connect you with the right resources. Start by typing a question below.</div>
+            </div>
+            <div class="chatbot-input">
+                <input type="text" placeholder="Type your message..." aria-label="Chatbot message input" disabled>
+                <button disabled>Send</button>
+            </div>
+        </div>
+        <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
+    </div>
+
+    <script src="ui.js"></script>
+<script>
         // Form step management
         let currentStep = 1;
         let selectedPackageType = '';

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,971 @@
+:root {
+    --bg-primary: #04060A;
+    --bg-secondary: rgba(18, 24, 34, 0.85);
+    --bg-elevated: rgba(28, 36, 50, 0.92);
+    --text-primary: #F8FAFF;
+    --text-secondary: #A5B4CE;
+    --accent-primary: #5B8CFF;
+    --accent-secondary: #7F5BFF;
+    --accent-success: #2FCB89;
+    --accent-warning: #FFB020;
+    --accent-danger: #F46363;
+    --border-soft: rgba(91, 140, 255, 0.18);
+    --glow: 0 20px 60px rgba(82, 108, 255, 0.25);
+    --radius-large: 28px;
+    --radius-medium: 18px;
+    --radius-small: 12px;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: radial-gradient(circle at top, rgba(91, 140, 255, 0.08) 0%, rgba(9, 12, 18, 0.95) 45%, #04060A 100%);
+    color: var(--text-primary);
+    min-height: 100vh;
+    line-height: 1.7;
+    position: relative;
+    overflow-x: hidden;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(91, 140, 255, 0.06), transparent 40%, rgba(47, 203, 137, 0.05) 70%, transparent 100%);
+    pointer-events: none;
+    z-index: -2;
+}
+
+body::after {
+    content: '';
+    position: fixed;
+    inset: -40vh -40vw;
+    background-image: radial-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+    background-size: 60px 60px;
+    opacity: 0.35;
+    pointer-events: none;
+    z-index: -3;
+}
+
+main {
+    display: block;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover {
+    color: #fff;
+}
+
+.text-gradient {
+    background: linear-gradient(120deg, var(--accent-primary), var(--accent-secondary));
+    -webkit-text-fill-color: transparent;
+    -webkit-background-clip: text;
+    background-clip: text;
+}
+
+.font-mono {
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+/* Navigation */
+.global-nav {
+    position: sticky;
+    top: 0;
+    width: 100%;
+    z-index: 80;
+    backdrop-filter: blur(20px);
+    background: rgba(8, 11, 20, 0.82);
+    border-bottom: 1px solid rgba(103, 140, 255, 0.18);
+    box-shadow: 0 15px 35px rgba(5, 8, 18, 0.6);
+}
+
+.global-nav.is-scrolled {
+    background: rgba(8, 11, 20, 0.94);
+    border-bottom-color: rgba(103, 140, 255, 0.28);
+    box-shadow: 0 25px 45px rgba(5, 8, 18, 0.75);
+}
+
+.nav-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+}
+
+.brandmark {
+    font-weight: 700;
+    font-size: 1.5rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+}
+
+.nav-links a,
+.nav-links button {
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-size: 0.95rem;
+    letter-spacing: 0.03em;
+    background: none;
+    border: none;
+    cursor: pointer;
+    position: relative;
+    padding: 0.35rem 0;
+    transition: color 0.3s ease;
+}
+
+.nav-links a::after,
+.nav-links button::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -0.4rem;
+    width: 0;
+    height: 2px;
+    background: linear-gradient(120deg, var(--accent-primary), var(--accent-secondary));
+    transition: width 0.3s ease;
+}
+
+.nav-links a:hover,
+.nav-links button:hover {
+    color: #fff;
+}
+
+.nav-links a:hover::after,
+.nav-links button:hover::after {
+    width: 100%;
+}
+
+.dropdown {
+    position: absolute;
+    top: calc(100% + 0.75rem);
+    left: 0;
+    background: rgba(14, 18, 28, 0.95);
+    border-radius: var(--radius-medium);
+    border: 1px solid rgba(91, 140, 255, 0.15);
+    padding: 1rem;
+    width: 220px;
+    box-shadow: var(--glow);
+    opacity: 0;
+    transform: translateY(-10px);
+    pointer-events: none;
+    transition: all 0.3s ease;
+}
+
+.group:hover .dropdown,
+.group:focus-within .dropdown,
+.dropdown.active {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.dropdown a {
+    display: block;
+    padding: 0.6rem 0.75rem;
+    border-radius: 10px;
+    color: var(--text-secondary);
+    transition: all 0.25s ease;
+}
+
+.dropdown a:hover {
+    color: #fff;
+    background: rgba(91, 140, 255, 0.1);
+}
+
+.nav-cta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.btn-primary,
+.nav-cta .primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.6rem;
+    border-radius: var(--radius-small);
+    background: linear-gradient(120deg, var(--accent-primary), #4A7CE8);
+    color: #fff;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    box-shadow: 0 12px 35px rgba(91, 140, 255, 0.35);
+}
+
+.btn-primary:hover,
+.nav-cta .primary:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 45px rgba(91, 140, 255, 0.45);
+}
+
+.btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.6rem;
+    border-radius: var(--radius-small);
+    border: 1px solid rgba(91, 140, 255, 0.35);
+    color: var(--accent-primary);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    background: rgba(91, 140, 255, 0.12);
+    transition: all 0.3s ease;
+}
+
+.btn-secondary:hover {
+    background: rgba(91, 140, 255, 0.2);
+    transform: translateY(-3px);
+}
+
+/* Hero */
+.hero-section {
+    position: relative;
+    padding-top: 7rem;
+    padding-bottom: 5rem;
+    overflow: hidden;
+}
+
+.hero-section::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(91, 140, 255, 0.28), transparent 55%),
+                radial-gradient(circle at 80% 10%, rgba(47, 203, 137, 0.18), transparent 50%);
+    opacity: 0.55;
+    z-index: -2;
+}
+
+.hero-grid {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 3rem;
+    align-items: center;
+}
+
+.hero-intro {
+    position: relative;
+    z-index: 1;
+}
+
+.hero-intro h1 {
+    font-size: clamp(2.75rem, 6vw, 4.5rem);
+    line-height: 1.1;
+    margin-bottom: 1.5rem;
+    letter-spacing: -0.02em;
+}
+
+.hero-intro p {
+    font-size: 1.125rem;
+    color: var(--text-secondary);
+    margin-bottom: 2.5rem;
+    max-width: 90%;
+}
+
+.hero-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.hero-stats {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.hero-card {
+    background: var(--bg-elevated);
+    border-radius: var(--radius-large);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 0 25px 45px rgba(8, 13, 24, 0.45);
+    padding: 1.8rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.hero-card::before {
+    content: '';
+    position: absolute;
+    inset: -40% 40% 60% -30%;
+    background: linear-gradient(120deg, rgba(91, 140, 255, 0.35), transparent 60%);
+    transform: rotate(8deg);
+    opacity: 0.6;
+}
+
+.hero-card h3 {
+    font-size: 1.35rem;
+    margin-bottom: 0.75rem;
+}
+
+.hero-card p {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.stat-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.stat-tile {
+    padding: 1.1rem;
+    border-radius: var(--radius-medium);
+    background: rgba(91, 140, 255, 0.08);
+    border: 1px solid rgba(91, 140, 255, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    backdrop-filter: blur(12px);
+}
+
+.stat-tile strong {
+    font-size: 1.25rem;
+    font-weight: 700;
+}
+
+/* Sections */
+.section-shell {
+    padding: 5rem 0;
+}
+
+.section-shell.alt {
+    background: rgba(10, 14, 24, 0.65);
+}
+
+.section-heading {
+    text-align: center;
+    font-size: clamp(2rem, 4vw, 3rem);
+    margin-bottom: 1rem;
+    letter-spacing: -0.015em;
+}
+
+.section-subheading {
+    text-align: center;
+    color: var(--text-secondary);
+    max-width: 680px;
+    margin: 0 auto 3rem;
+    font-size: 1.05rem;
+}
+
+.glass-card,
+.card-hover,
+.team-card,
+.pricing-card,
+.contact-card,
+.dashboard-card,
+.result-card,
+.library-card,
+.training-module,
+.methodology-card,
+.modal-content,
+.authentication-panel,
+.alert-info,
+.alert-warning,
+.alert-critical,
+.alert-level,
+.department-card,
+.faq-item,
+.cookie-category,
+.cookie-table,
+.blog-card,
+.equipment-card,
+.stats-card,
+.payment-method,
+.methodology-card,
+.search-bar,
+.search-result-item,
+.spectrum-viewer,
+.share-option,
+.sms-form,
+.gallery-item,
+.timeline-item,
+.step,
+.filter-input,
+.form-input,
+.category-filter,
+.filter-btn {
+    background: var(--bg-secondary);
+    border-radius: var(--radius-medium);
+    border: 1px solid var(--border-soft);
+    box-shadow: 0 20px 45px rgba(5, 9, 18, 0.45);
+    transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease, background 0.35s ease;
+}
+
+.card-hover:hover,
+.glass-card:hover,
+.team-card:hover,
+.pricing-card:hover,
+.contact-card:hover,
+.dashboard-card:hover,
+.blog-card:hover,
+.equipment-card:hover,
+.stats-card:hover,
+.library-card:hover,
+.training-module:hover,
+.methodology-card:hover,
+.result-card:hover,
+.search-result-item:hover,
+.share-option:hover,
+.payment-method:hover {
+    transform: translateY(-6px);
+    border-color: rgba(91, 140, 255, 0.45);
+    box-shadow: 0 28px 60px rgba(12, 16, 30, 0.6);
+}
+
+/* Buttons & badges */
+.status-badge,
+.status-danger,
+.status-warning,
+.status-safe {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.status-danger { background: rgba(244, 99, 99, 0.2); color: var(--accent-danger); border: 1px solid rgba(244, 99, 99, 0.35); }
+.status-warning { background: rgba(255, 176, 32, 0.18); color: var(--accent-warning); border: 1px solid rgba(255, 176, 32, 0.35); }
+.status-safe { background: rgba(47, 203, 137, 0.18); color: var(--accent-success); border: 1px solid rgba(47, 203, 137, 0.35); }
+
+.risk-high { color: var(--accent-danger); }
+.risk-medium { color: var(--accent-warning); }
+.risk-low { color: var(--accent-success); }
+
+.category-badge,
+.alert-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.category-policy { background: rgba(91, 140, 255, 0.18); color: var(--accent-primary); }
+.category-harm-reduction { background: rgba(47, 203, 137, 0.18); color: var(--accent-success); }
+.category-safety { background: rgba(255, 176, 32, 0.2); color: var(--accent-warning); }
+.category-research { background: rgba(127, 91, 255, 0.18); color: var(--accent-secondary); }
+
+.alert-info { border-left: 4px solid var(--accent-primary); }
+.alert-warning { border-left: 4px solid var(--accent-warning); }
+.alert-critical { border-left: 4px solid var(--accent-danger); }
+.alert-level { border-left: 4px solid rgba(255, 255, 255, 0.2); }
+
+/* Tables */
+.data-table,
+.cookie-table {
+    background: rgba(10, 14, 22, 0.72);
+    border-radius: var(--radius-large);
+    border: 1px solid rgba(91, 140, 255, 0.18);
+    overflow: hidden;
+    backdrop-filter: blur(14px);
+}
+
+.table-header,
+.cookie-table thead {
+    background: rgba(91, 140, 255, 0.12);
+    border-bottom: 1px solid rgba(91, 140, 255, 0.18);
+}
+
+.table-row,
+.cookie-table tbody tr {
+    transition: background 0.3s ease;
+}
+
+.table-row:hover,
+.cookie-table tbody tr:hover {
+    background: rgba(91, 140, 255, 0.06);
+}
+
+/* Forms */
+.filter-input,
+.form-input,
+.search-bar,
+.sms-form {
+    background: rgba(14, 18, 28, 0.85);
+    border-radius: var(--radius-small);
+    border: 1px solid rgba(91, 140, 255, 0.2);
+    padding: 0.95rem 1.1rem;
+    color: var(--text-primary);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.filter-input:focus,
+.form-input:focus,
+.search-bar:focus,
+.sms-form:focus {
+    outline: none;
+    border-color: rgba(91, 140, 255, 0.5);
+    box-shadow: 0 0 0 4px rgba(91, 140, 255, 0.15);
+}
+
+.search-bar {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+}
+
+.category-filter,
+.filter-btn,
+.faq-question {
+    background: rgba(12, 18, 28, 0.92);
+    border-radius: var(--radius-small);
+    border: 1px solid rgba(91, 140, 255, 0.18);
+    padding: 0.85rem 1.1rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.filter-btn.active,
+.category-filter.active {
+    color: #fff;
+    border-color: rgba(91, 140, 255, 0.45);
+    background: rgba(91, 140, 255, 0.18);
+}
+
+.faq-item {
+    padding: 1.25rem 1.5rem;
+}
+
+.faq-question {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.faq-answer {
+    color: var(--text-secondary);
+    margin-top: 1rem;
+    border-top: 1px solid rgba(91, 140, 255, 0.15);
+    padding-top: 1rem;
+}
+
+/* Timeline & cards */
+.timeline-item {
+    position: relative;
+    padding-left: 2.5rem;
+}
+
+.timeline-item::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.35rem;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: linear-gradient(120deg, var(--accent-primary), var(--accent-secondary));
+    box-shadow: 0 0 12px rgba(91, 140, 255, 0.6);
+}
+
+.timeline-item::after {
+    content: '';
+    position: absolute;
+    left: 6px;
+    top: 1.4rem;
+    width: 2px;
+    height: calc(100% - 0.5rem);
+    background: linear-gradient(180deg, rgba(91, 140, 255, 0.18), transparent);
+}
+
+.stats-card {
+    padding: 1.6rem;
+}
+
+.stats-card h3 {
+    font-size: 1.15rem;
+    margin-bottom: 0.35rem;
+}
+
+.gallery-item,
+.gallery-image {
+    border-radius: var(--radius-medium);
+    overflow: hidden;
+}
+
+.blog-card {
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.blog-image {
+    border-radius: var(--radius-medium);
+    overflow: hidden;
+}
+
+/* Market monitoring / analytics cards */
+.dashboard-card,
+.methodology-card,
+.geographic-map,
+.chart-container {
+    padding: 1.75rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.dashboard-card::before,
+.methodology-card::before,
+.result-card::before,
+.training-module::before,
+.library-card::before {
+    content: '';
+    position: absolute;
+    inset: -20% 60% 70% -30%;
+    background: radial-gradient(circle, rgba(91, 140, 255, 0.35), transparent 70%);
+    opacity: 0.45;
+}
+
+.chart-container {
+    min-height: 320px;
+}
+
+.geographic-map {
+    min-height: 360px;
+    border-radius: var(--radius-large);
+    border: 1px solid rgba(91, 140, 255, 0.18);
+}
+
+.alert-level,
+.alert-info,
+.alert-warning,
+.alert-critical {
+    padding: 1.1rem 1.4rem;
+}
+
+/* Pricing & steps */
+.pricing-card {
+    padding: 1.75rem;
+    background: linear-gradient(145deg, rgba(16, 20, 32, 0.95), rgba(10, 14, 24, 0.9));
+}
+
+.pricing-card.featured {
+    background: linear-gradient(145deg, rgba(91, 140, 255, 0.18), rgba(47, 203, 137, 0.12));
+    border: 1px solid rgba(91, 140, 255, 0.45);
+    box-shadow: 0 24px 55px rgba(91, 140, 255, 0.35);
+}
+
+.step-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+}
+
+.step {
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 1rem;
+    border-radius: 50%;
+    background: rgba(12, 18, 28, 0.9);
+    border: 2px solid rgba(91, 140, 255, 0.25);
+}
+
+.step.active {
+    background: linear-gradient(130deg, var(--accent-primary), var(--accent-secondary));
+    border-color: transparent;
+    box-shadow: 0 12px 30px rgba(91, 140, 255, 0.35);
+}
+
+.step.completed {
+    background: rgba(47, 203, 137, 0.25);
+    border-color: rgba(47, 203, 137, 0.6);
+}
+
+.step-connector {
+    flex: 1;
+    height: 2px;
+    background: rgba(91, 140, 255, 0.2);
+}
+
+.step-connector.completed {
+    background: linear-gradient(120deg, rgba(47, 203, 137, 0.8), rgba(91, 140, 255, 0.8));
+}
+
+.payment-method {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.1rem 1.3rem;
+    background: rgba(12, 18, 28, 0.95);
+}
+
+.payment-method.selected {
+    border-color: rgba(91, 140, 255, 0.55);
+    background: rgba(91, 140, 255, 0.18);
+    box-shadow: 0 16px 40px rgba(91, 140, 255, 0.35);
+}
+
+/* Results */
+.result-card,
+.authentication-panel,
+.spectrum-viewer,
+.modal-content,
+.share-option {
+    padding: 1.75rem;
+}
+
+.authentication-panel {
+    border: 1px solid rgba(47, 203, 137, 0.35);
+}
+
+.spectrum-viewer {
+    min-height: 280px;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(4, 7, 12, 0.85);
+    backdrop-filter: blur(12px);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    z-index: 200;
+}
+
+.modal.active {
+    display: flex;
+}
+
+.modal-content {
+    max-width: 640px;
+    width: 100%;
+}
+
+/* Legal */
+.legal-nav {
+    display: grid;
+    gap: 1rem;
+}
+
+.legal-section {
+    padding: 2rem;
+    border-radius: var(--radius-large);
+    background: rgba(12, 18, 28, 0.9);
+    border: 1px solid rgba(91, 140, 255, 0.18);
+    box-shadow: 0 18px 45px rgba(10, 15, 28, 0.5);
+}
+
+.cookie-category {
+    padding: 1.35rem;
+}
+
+.cookie-essential { border-left: 4px solid rgba(91, 140, 255, 0.45); }
+.cookie-analytics { border-left: 4px solid rgba(255, 176, 32, 0.45); }
+.cookie-marketing { border-left: 4px solid rgba(244, 99, 99, 0.45); }
+
+/* Footer */
+.site-footer {
+    background: rgba(5, 8, 14, 0.92);
+    border-top: 1px solid rgba(91, 140, 255, 0.18);
+    padding: 3rem 0;
+    margin-top: 5rem;
+}
+
+.footer-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 2.5rem;
+}
+
+.footer-meta {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.footer-bottom {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid rgba(91, 140, 255, 0.12);
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+/* Chatbot widget */
+.chatbot-widget {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 120;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.75rem;
+}
+
+.chatbot-toggle {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    border: none;
+    cursor: pointer;
+    background: linear-gradient(130deg, var(--accent-primary), var(--accent-secondary));
+    color: #fff;
+    font-size: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 18px 45px rgba(91, 140, 255, 0.45);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.chatbot-toggle:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 24px 55px rgba(91, 140, 255, 0.55);
+}
+
+.chatbot-window {
+    width: min(360px, 90vw);
+    max-height: 520px;
+    border-radius: 24px;
+    background: rgba(10, 14, 24, 0.96);
+    border: 1px solid rgba(91, 140, 255, 0.35);
+    box-shadow: 0 30px 60px rgba(6, 10, 20, 0.7);
+    display: none;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.chatbot-window.active {
+    display: flex;
+}
+
+.chatbot-header {
+    padding: 1.1rem 1.25rem;
+    background: linear-gradient(120deg, rgba(91, 140, 255, 0.24), rgba(12, 18, 28, 0.95));
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.chatbot-body {
+    padding: 1.1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    overflow-y: auto;
+}
+
+.chatbot-message {
+    padding: 0.75rem 0.95rem;
+    border-radius: var(--radius-medium);
+    background: rgba(91, 140, 255, 0.12);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.chatbot-input {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-top: 1px solid rgba(91, 140, 255, 0.18);
+    background: rgba(12, 18, 28, 0.95);
+}
+
+.chatbot-input input {
+    flex: 1;
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-small);
+    border: 1px solid rgba(91, 140, 255, 0.2);
+    background: rgba(8, 12, 20, 0.95);
+    color: var(--text-primary);
+}
+
+.chatbot-input button {
+    padding: 0.7rem 1.1rem;
+    border-radius: var(--radius-small);
+    border: none;
+    background: linear-gradient(120deg, var(--accent-primary), var(--accent-secondary));
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.3s ease;
+}
+
+.chatbot-input button:hover {
+    transform: translateY(-2px);
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .nav-links {
+        display: none;
+    }
+
+    .nav-cta {
+        margin-left: auto;
+    }
+}
+
+@media (max-width: 768px) {
+    .hero-intro p {
+        max-width: 100%;
+    }
+
+    .section-shell {
+        padding: 3.75rem 0;
+    }
+
+    .footer-inner {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 640px) {
+    .hero-cta {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .nav-cta {
+        display: none;
+    }
+}

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,50 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const nav = document.querySelector('.global-nav');
+    const toggle = document.querySelector('[data-chatbot-toggle]');
+    const closeBtn = document.querySelector('[data-chatbot-close]');
+    const chatbotWindow = document.querySelector('#chatbotWindow');
+
+    if (nav) {
+        const updateNavState = () => {
+            if (window.scrollY > 40) {
+                nav.classList.add('is-scrolled');
+            } else {
+                nav.classList.remove('is-scrolled');
+            }
+        };
+        updateNavState();
+        window.addEventListener('scroll', updateNavState, { passive: true });
+    }
+
+    const toggleChatbot = (forceState) => {
+        if (!chatbotWindow || !toggle) {
+            return;
+        }
+        const shouldOpen = typeof forceState === 'boolean' ? forceState : !chatbotWindow.classList.contains('active');
+        chatbotWindow.classList.toggle('active', shouldOpen);
+        toggle.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+        chatbotWindow.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
+    };
+
+    if (toggle) {
+        toggle.addEventListener('click', () => toggleChatbot());
+    }
+
+    if (closeBtn) {
+        closeBtn.addEventListener('click', () => toggleChatbot(false));
+    }
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            toggleChatbot(false);
+        }
+    });
+
+    document.addEventListener('click', (event) => {
+        if (!chatbotWindow || !toggle) return;
+        const isClickInside = chatbotWindow.contains(event.target) || toggle.contains(event.target);
+        if (!isClickInside && chatbotWindow.classList.contains('active')) {
+            toggleChatbot(false);
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add a comprehensive styles.css theme to deliver a premium visual system across navigation, hero panels, sections, and the new chatbot widget
- implement ui.js to handle navigation scroll states and the floating virtual assistant toggle
- refresh every HTML page to consume the shared styles, updated navigation/footer, and embedded chatbot surface

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4671ecf80832b9a7a5fb3ca3bb747