### PR TITLE
Ensure particle background container does not shift layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body id="top">
-    <div id="particles-container"></div>
 
     <nav class="global-nav">
         <div class="nav-container">
@@ -318,6 +317,8 @@
         </div>
         <button class="chatbot-toggle" aria-expanded="false" aria-controls="chatbotWindow" data-chatbot-toggle>💬</button>
     </div>
+
+    <div id="particles-container" aria-hidden="true"></div>
 
     <script src="main.js"></script>
     <script src="ui.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,21 @@ body {
     overflow-x: hidden;
 }
 
+#particles-container {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: -1;
+    pointer-events: none;
+}
+
+#particles-container canvas {
+    display: block;
+    width: 100% !important;
+    height: 100% !important;
+}
+
 body::before {
     content: '';
     position: fixed;


### PR DESCRIPTION
## Summary
- relocate the particle background container to the end of the page so it cannot push the navigation on initial load
- lock the particle overlay to the viewport with explicit width and height to prevent layout shifts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee74ff01bc832b9e255fb10e4028de