### PR TITLE
Improve hero CTA contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,6 @@
         <section class="hero-section">
             <div class="hero-grid">
                 <div class="hero-intro">
-                    <span class="category-badge category-research">Public service laboratory</span>
                     <h1>
                         <span class="text-gradient" id="typed-headline"></span>
                     </h1>

--- a/styles.css
+++ b/styles.css
@@ -238,16 +238,20 @@ a:hover {
     justify-content: center;
     padding: 0.85rem 1.6rem;
     border-radius: var(--radius-small);
-    border: 1px solid rgba(91, 140, 255, 0.35);
-    color: var(--accent-primary);
+    border: 1px solid rgba(149, 184, 255, 0.6);
+    color: #E6ECFF;
     font-weight: 600;
     letter-spacing: 0.04em;
-    background: rgba(91, 140, 255, 0.12);
+    background: linear-gradient(120deg, rgba(91, 140, 255, 0.28), rgba(127, 91, 255, 0.32));
+    box-shadow: 0 12px 32px rgba(91, 140, 255, 0.28);
     transition: all 0.3s ease;
 }
 
 .btn-secondary:hover {
-    background: rgba(91, 140, 255, 0.2);
+    background: linear-gradient(120deg, rgba(91, 140, 255, 0.38), rgba(127, 91, 255, 0.45));
+    border-color: rgba(176, 204, 255, 0.75);
+    color: #fff;
+    box-shadow: 0 16px 42px rgba(91, 140, 255, 0.38);
     transform: translateY(-3px);
 }
 
@@ -293,9 +297,10 @@ a:hover {
 
 .hero-intro p {
     font-size: 1.125rem;
-    color: var(--text-secondary);
+    color: rgba(248, 250, 255, 0.92);
     margin-bottom: 2.5rem;
     max-width: 90%;
+    text-shadow: 0 8px 30px rgba(4, 6, 10, 0.6);
 }
 
 .hero-cta {


### PR DESCRIPTION
## Summary
- brighten the hero paragraph text on the homepage to ensure sufficient contrast against the dark background
- add a subtle text shadow so the introductory copy remains legible over gradients and background effects
- enhance secondary hero call-to-action buttons with brighter fills and glows so they read clearly against the dark hero gradient
- remove the “Public service laboratory” label above the hero headline per feedback

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ee8481fcc0832b9037a5a279a35373